### PR TITLE
TCP stream fixes. Finer `protocol::command` control. Enable TCP_NODELAY. Expose more **TcpStream** methods.

### DIFF
--- a/dac-emulator/src/listener.rs
+++ b/dac-emulator/src/listener.rs
@@ -142,6 +142,60 @@ impl ActiveStream {
     pub fn close(mut self) -> io::Error {
         self.close_inner()
     }
+
+    /// This directly calls `set_nodelay` on the inner **TcpStream**. In other words, this sets the
+    /// value of the TCP_NODELAY option for this socket.
+    ///
+    /// Note that due to the necessity for very low-latency communication with the DAC, this API
+    /// enables `TCP_NODELAY` by default. This method is exposed in order to allow the user to
+    /// disable this if they wish.
+    ///
+    /// When not set, data is buffered until there is a sufficient amount to send out, thereby
+    /// avoiding the frequent sending of small packets. Although perhaps more efficient for the
+    /// network, this may result in DAC underflows if **Data** commands are delayed for too long.
+    pub fn set_nodelay(&self, b: bool) -> io::Result<()> {
+        if let Some((stream_handle, _)) = self.inner.as_ref() {
+            stream_handle.set_nodelay(b)
+        } else {
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "called `set_nodelay` on a closed stream"))
+        }
+    }
+
+    /// Gets the value of the TCP_NODELAY option for this socket.
+    ///
+    /// For more infnormation about this option, see `set_nodelay`.
+    pub fn nodelay(&self) -> io::Result<bool> {
+        if let Some((stream_handle, _)) = self.inner.as_ref() {
+            stream_handle.nodelay()
+        } else {
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "called `nodelay` on a closed stream"))
+        }
+    }
+
+    /// This directly calls `set_ttl` on the inner **TcpStream**. In other words, this sets the
+    /// value for the `IP_TTL` option on this socket.
+    ///
+    /// This value sets the time-to-live field that is used in every packet sent from this socket.
+    /// Time-to-live describes the number of hops between devices that a packet may make before it
+    /// is discarded/ignored.
+    pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
+        if let Some((stream_handle, _)) = self.inner.as_ref() {
+            stream_handle.set_ttl(ttl)
+        } else {
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "called `set_ttl` on a closed stream"))
+        }
+    }
+
+    /// Gets the value of the `IP_TTL` option for this socket.
+    ///
+    /// For more information about this option see `set_ttl`.
+    pub fn ttl(&self) -> io::Result<u32> {
+        if let Some((stream_handle, _)) = self.inner.as_ref() {
+            stream_handle.ttl()
+        } else {
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "called `ttl` on a closed stream"))
+        }
+    }
 }
 
 impl Drop for ActiveStream {

--- a/dac-emulator/src/stream/mod.rs
+++ b/dac-emulator/src/stream/mod.rs
@@ -53,50 +53,6 @@ pub enum InterpretedCommand {
     Unknown { start_byte: u8 }
 }
 
-/// Attempt to interpret the given bytes as a **Command**.
-///
-/// **Panics** if the given slice of bytes is empty.
-pub fn interpret_command(mut bytes: &[u8]) -> io::Result<InterpretedCommand> {
-    let interpreted_command = match bytes[0] {
-        command::PrepareStream::START_BYTE => {
-            let prepare_stream = bytes.read_bytes::<command::PrepareStream>()?;
-            Command::PrepareStream(prepare_stream).into()
-        },
-        command::Begin::START_BYTE => {
-            let begin = bytes.read_bytes::<command::Begin>()?;
-            Command::Begin(begin).into()
-        },
-        command::PointRate::START_BYTE => {
-            let point_rate = bytes.read_bytes::<command::PointRate>()?;
-            Command::PointRate(point_rate).into()
-        },
-        command::Data::START_BYTE => {
-            let data = bytes.read_bytes::<command::Data<'static>>()?;
-            Command::Data(data).into()
-        },
-        command::Stop::START_BYTE => {
-            let stop = bytes.read_bytes::<command::Stop>()?;
-            Command::Stop(stop).into()
-        },
-        command::EmergencyStop::START_BYTE => {
-            let emergency_stop = bytes.read_bytes::<command::EmergencyStop>()?;
-            Command::EmergencyStop(emergency_stop).into()
-        },
-        command::ClearEmergencyStop::START_BYTE => {
-            let clear_emergency_stop = bytes.read_bytes::<command::ClearEmergencyStop>()?;
-            Command::ClearEmergencyStop(clear_emergency_stop).into()
-        },
-        command::Ping::START_BYTE => {
-            let ping = bytes.read_bytes::<command::Ping>()?;
-            Command::Ping(ping).into()
-        },
-        start_byte => {
-            InterpretedCommand::Unknown { start_byte }
-        },
-    };
-    Ok(interpreted_command)
-}
-
 impl Handle {
     /// Produce a handle to the **Output** of the stream.
     ///
@@ -200,6 +156,87 @@ impl Stream {
     }
 }
 
+impl InterpretedCommand {
+    /// Read a single command from the TCP stream and return it.
+    ///
+    /// This method blocks until the exact number of bytes necessary for the returned command are
+    /// read.
+    pub fn read_from_tcp_stream(
+        bytes: &mut [u8],
+        tcp_stream: &mut net::TcpStream,
+    ) -> io::Result<Self>
+    {
+        // Peek the first byte to determine the command kind.
+        bytes[0] = 0u8;
+        let len = tcp_stream.peek(&mut bytes[..1])?;
+
+        // Empty messages should only happen if the stream has closed.
+        if len == 0 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "read `0` bytes from tcp stream"));
+        }
+
+        // Read the rest of the command from the stream based on the starting byte.
+        let interpreted_command = match bytes[0] {
+            command::PrepareStream::START_BYTE => {
+                tcp_stream.read_exact(&mut bytes[..command::PrepareStream::SIZE_BYTES])?;
+                let prepare_stream = (&bytes[..]).read_bytes::<command::PrepareStream>()?;
+                Command::PrepareStream(prepare_stream).into()
+            },
+            command::Begin::START_BYTE => {
+                tcp_stream.read_exact(&mut bytes[..command::Begin::SIZE_BYTES])?;
+                let begin = (&bytes[..]).read_bytes::<command::Begin>()?;
+                Command::Begin(begin).into()
+            },
+            command::PointRate::START_BYTE => {
+                tcp_stream.read_exact(&mut bytes[..command::PointRate::SIZE_BYTES])?;
+                let point_rate = (&bytes[..]).read_bytes::<command::PointRate>()?;
+                Command::PointRate(point_rate).into()
+            },
+            command::Data::START_BYTE => {
+                // Read the number of points.
+                let command_bytes = 1;
+                let n_points_bytes = 2;
+                let n_points_start = command_bytes;
+                let n_points_end = n_points_start + n_points_bytes;
+                tcp_stream.peek(&mut bytes[..n_points_end])?;
+                let n_points = command::Data::read_n_points(&bytes[n_points_start..n_points_end])?;
+
+                // Use the number of points to determine how many bytes to read.
+                let data_bytes = n_points as usize * protocol::DacPoint::SIZE_BYTES;
+                let total_bytes = command_bytes + n_points_bytes + data_bytes;
+                tcp_stream.read_exact(&mut bytes[..total_bytes])?;
+                let data = (&bytes[..]).read_bytes::<command::Data<'static>>()?;
+                Command::Data(data).into()
+            },
+            command::Stop::START_BYTE => {
+                tcp_stream.read_exact(&mut bytes[..command::Stop::SIZE_BYTES])?;
+                let stop = (&bytes[..]).read_bytes::<command::Stop>()?;
+                Command::Stop(stop).into()
+            },
+            command::EmergencyStop::START_BYTE => {
+                tcp_stream.read_exact(&mut bytes[..command::EmergencyStop::SIZE_BYTES])?;
+                let emergency_stop = (&bytes[..]).read_bytes::<command::EmergencyStop>()?;
+                Command::EmergencyStop(emergency_stop).into()
+            },
+            command::ClearEmergencyStop::START_BYTE => {
+                tcp_stream.read_exact(&mut bytes[..command::ClearEmergencyStop::SIZE_BYTES])?;
+                let clear_emergency_stop = (&bytes[..]).read_bytes::<command::ClearEmergencyStop>()?;
+                Command::ClearEmergencyStop(clear_emergency_stop).into()
+            },
+            command::Ping::START_BYTE => {
+                tcp_stream.read_exact(&mut bytes[..command::Ping::SIZE_BYTES])?;
+                let ping = (&bytes[..]).read_bytes::<command::Ping>()?;
+                Command::Ping(ping).into()
+            },
+            start_byte => {
+                InterpretedCommand::Unknown { start_byte }
+            },
+        };
+
+        Ok(interpreted_command)
+    }
+}
+
 impl From<Command> for InterpretedCommand {
     fn from(command: Command) -> Self {
         InterpretedCommand::Known { command }
@@ -217,16 +254,8 @@ fn read_command_via_tcp_and_respond(stream: &mut Stream) -> io::Result<()> {
         ref output_processor,
     } = *stream;
 
-    // Receive bytes from the TCP stream.
-    let len = tcp_stream.read(bytes)?;
-
-    // Empty messages should be skipped.
-    if bytes.is_empty() || len == 0 {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "read `0` bytes from tcp stream"));
-    }
-
-    // Attempt to interpret the bytes as a command.
-    let interpreted_command = interpret_command(&bytes[..len])?;
+    // Read the command from the TCP stream.
+    let interpreted_command = InterpretedCommand::read_from_tcp_stream(bytes, tcp_stream)?;
 
     // Process command here.
     let dac_response = process_interpreted_command(dac, interpreted_command, output_processor);
@@ -414,22 +443,3 @@ pub fn process_command(
         dac_status,
     }
 }
-
-// /// Spawn a stream that receives **Command**s sent by the user via the given TCP stream, processes
-// /// them, updates the DAC state accordingly and responds via the TCP stream.
-// ///
-// /// Returns a **Handle** to the two stream threads: "tcp-handler" and "command-processor".
-// pub fn spawn(dac: dac::Addressed, tcp_stream: net::TcpStream) -> io::Result<Handle> {
-//     // Spawn the tcp handling thread.
-//     let buffer_capacity = dac.buffer_capacity as usize;
-//     let tcp_handler_thread = thread::Builder::new()
-//         .name("ether-dream-dac-emulator-stream".into())
-//         .spawn(move || {
-//             run(dac, tcp_stream, buffer_capacity)
-//         })?;
-// 
-//     // Create the handle to the streams.
-//     let handle = Handle { stream_thread };
-// 
-//     Ok(handle)
-// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ impl RecvDacBroadcasts {
 /// ```
 pub fn recv_dac_broadcasts() -> io::Result<RecvDacBroadcasts> {
     let broadcast_port = protocol::BROADCAST_PORT;
-    let broadcast_addr = net::SocketAddrV4::new([255, 255, 255, 255].into(), broadcast_port);
+    let broadcast_addr = net::SocketAddrV4::new([0, 0, 0, 0].into(), broadcast_port);
     let udp_socket = net::UdpSocket::bind(broadcast_addr)?;
     let buffer = [0; RecvDacBroadcasts::BUFFER_LEN];
     Ok(RecvDacBroadcasts { udp_socket, buffer })

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -538,6 +538,82 @@ pub mod command {
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
     pub struct Ping;
 
+    impl Begin {
+        /// Consecutively read the fields of the **Begin** type and return a **Begin** instance.
+        ///
+        /// Note that if reading from a stream, this method assumes that the starting command byte
+        /// has already been read.
+        pub fn read_fields<R: ReadBytesExt>(mut reader: R) -> io::Result<Self> {
+            let low_water_mark = reader.read_u16::<LE>()?;
+            let point_rate = reader.read_u32::<LE>()?;
+            let begin = Begin { low_water_mark, point_rate };
+            Ok(begin)
+        }
+    }
+
+    impl PointRate {
+        /// Consecutively read the fields of the **PointRate** type and return a **PointRate** instance.
+        ///
+        /// Note that if reading from a stream, this method assumes that the starting command byte
+        /// has already been read.
+        pub fn read_fields<R: ReadBytesExt>(mut reader: R) -> io::Result<Self> {
+            let point_rate = PointRate(reader.read_u32::<LE>()?);
+            Ok(point_rate)
+        }
+    }
+
+    impl Data<'static> {
+        /// Read the `u16` representing the number of points within the **Data** from the given
+        /// `reader`.
+        ///
+        /// This method is useful for determining how many more bytes should be read from a stream.
+        ///
+        /// Note that if reading from a stream, this method assumes that the starting command byte
+        /// has already been read.
+        pub fn read_n_points<R>(mut reader: R) -> io::Result<u16>
+        where
+            R: ReadBytesExt,
+        {
+            reader.read_u16::<LE>()
+        }
+
+        /// Read and append the given number of points into the given Vec of **DacPoint**s.
+        ///
+        /// This method is useful as an alternative to **Self::read_fields** or
+        /// **Self::read_from_bytes** as it allows for re-using a buffer of points rather than
+        /// dynamically allocating a new one each time.
+        ///
+        /// Note that if reading from a stream, this method assumes that the starting command byte
+        /// and the `u16` representing the number of points have both already been read.
+        pub fn read_points<R>(
+            mut reader: R,
+            mut n_points: u16,
+            points: &mut Vec<DacPoint>,
+        ) -> io::Result<()>
+        where
+            R: ReadBytesExt,
+        {
+            while n_points > 0 {
+                let dac_point = reader.read_bytes::<DacPoint>()?;
+                points.push(dac_point);
+                n_points -= 1;
+            }
+            Ok(())
+        }
+
+        /// Consecutively read the fields of the **Data** type and return a **Data** instance.
+        ///
+        /// Note that if reading from a stream, this method assumes that the starting command byte
+        /// has already been read.
+        pub fn read_fields<R: ReadBytesExt>(mut reader: R) -> io::Result<Self> {
+            let n_points = Self::read_n_points(&mut reader)?;
+            let mut data = Vec::with_capacity(n_points as _);
+            Self::read_points(reader, n_points, &mut data)?;
+            let data = Data { points: Cow::Owned(data) };
+            Ok(data)
+        }
+    }
+
     impl<'a, C> Command for &'a C
     where
         C: Command,
@@ -700,10 +776,7 @@ pub mod command {
                 let err_msg = "invalid \"begin\" command byte";
                 return Err(io::Error::new(io::ErrorKind::InvalidData, err_msg));
             }
-            let low_water_mark = reader.read_u16::<LE>()?;
-            let point_rate = reader.read_u32::<LE>()?;
-            let begin = Begin { low_water_mark, point_rate };
-            Ok(begin)
+            Self::read_fields(reader)
         }
     }
 
@@ -713,8 +786,7 @@ pub mod command {
                 let err_msg = "invalid \"queue change\" command byte";
                 return Err(io::Error::new(io::ErrorKind::InvalidData, err_msg));
             }
-            let point_rate = PointRate(reader.read_u32::<LE>()?);
-            Ok(point_rate)
+            Self::read_fields(reader)
         }
     }
 
@@ -724,16 +796,7 @@ pub mod command {
                 let err_msg = "invalid \"data\" command byte";
                 return Err(io::Error::new(io::ErrorKind::InvalidData, err_msg));
             }
-            let n_points = reader.read_u16::<LE>()?;
-            let mut data = Vec::with_capacity(n_points as _);
-            let mut points = n_points;
-            while points > 0 {
-                let dac_point = reader.read_bytes::<DacPoint>()?;
-                data.push(dac_point);
-                points -= 1;
-            }
-            let data = Data { points: Cow::Owned(data) };
-            Ok(data)
+            Self::read_fields(reader)
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -562,7 +562,7 @@ pub mod command {
         }
     }
 
-    impl Data<'static> {
+    impl<'a> Data<'a> {
         /// Read the `u16` representing the number of points within the **Data** from the given
         /// `reader`.
         ///
@@ -600,7 +600,9 @@ pub mod command {
             }
             Ok(())
         }
+    }
 
+    impl Data<'static> {
         /// Consecutively read the fields of the **Data** type and return a **Data** instance.
         ///
         /// Note that if reading from a stream, this method assumes that the starting command byte


### PR DESCRIPTION
Fixes a bug where the UDP broadcast listener attempted to bind to the broadcast IP `255.255.255.255`. It instead now binds to `0.0.0.0`.

Methods have been added to the `Begin`, `PointRate` and `Data` commands to allow for more fine-grained reading of the fields from bytes.

Fixes an incorrect implementation of TCP stream reading. Streams now properly check that they've received the correct number of bytes before attempting to decode a command or response.

Enables `TCP_NODELAY` to reduce latency to adhere to the realtime requirements of laser DAC communication.