### PR TITLE
 Only check for bit flags specified in protocol - truncate remaining bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ether-dream"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A full implementation of the Ether Dream Laster DAC protocol."
 readme = "README.md"

--- a/src/dac/mod.rs
+++ b/src/dac/mod.rs
@@ -158,6 +158,10 @@ bitflags! {
         ///
         /// This is reset to zero by the `Prepare` command.
         const EMERGENCY_STOP = 0b00000100;
+        /// Undocumented bit set sent by an Ether Dream DAC during broadcast with hw_version `10`.
+        ///
+        /// Doesn't seem to impact playback. First three bits still seem valid.
+        const UNKNOWN_HW10 = 0b1101000000010000;
     }
 }
 

--- a/src/dac/mod.rs
+++ b/src/dac/mod.rs
@@ -158,10 +158,6 @@ bitflags! {
         ///
         /// This is reset to zero by the `Prepare` command.
         const EMERGENCY_STOP = 0b00000100;
-        /// Undocumented bit set sent by an Ether Dream DAC during broadcast with hw_version `10`.
-        ///
-        /// Doesn't seem to impact playback. First three bits still seem valid.
-        const UNKNOWN_HW10 = 0b1101000000010000;
     }
 }
 
@@ -214,8 +210,6 @@ pub enum ProtocolError {
     UnknownLightEngineState,
     UnknownPlaybackState,
     UnknownDataSource,
-    UnknownLightEngineFlags,
-    UnknownPlaybackFlags,
 }
 
 impl Addressed {
@@ -260,10 +254,8 @@ impl Status {
             .ok_or(ProtocolError::UnknownPlaybackState)?;
         let data_source = DataSource::from_protocol(status.source, status.source_flags)
             .ok_or(ProtocolError::UnknownDataSource)?;
-        let light_engine_flags = LightEngineFlags::from_bits(status.light_engine_flags)
-            .ok_or(ProtocolError::UnknownLightEngineFlags)?;
-        let playback_flags = PlaybackFlags::from_bits(status.playback_flags)
-            .ok_or(ProtocolError::UnknownPlaybackFlags)?;
+        let light_engine_flags = LightEngineFlags::from_bits_truncate(status.light_engine_flags);
+        let playback_flags = PlaybackFlags::from_bits_truncate(status.playback_flags);
         let buffer_fullness = status.buffer_fullness;
         let point_rate = status.point_rate;
         let point_count = status.point_count;
@@ -289,10 +281,8 @@ impl Status {
             .ok_or(ProtocolError::UnknownPlaybackState)?;
         self.data_source = DataSource::from_protocol(status.source, status.source_flags)
             .ok_or(ProtocolError::UnknownDataSource)?;
-        self.light_engine_flags = LightEngineFlags::from_bits(status.light_engine_flags)
-            .ok_or(ProtocolError::UnknownLightEngineFlags)?;
-        self.playback_flags = PlaybackFlags::from_bits(status.playback_flags)
-            .ok_or(ProtocolError::UnknownPlaybackFlags)?;
+        self.light_engine_flags = LightEngineFlags::from_bits_truncate(status.light_engine_flags);
+        self.playback_flags = PlaybackFlags::from_bits_truncate(status.playback_flags);
         self.buffer_fullness = status.buffer_fullness;
         self.point_rate = status.point_rate;
         self.point_count = status.point_count;
@@ -385,11 +375,11 @@ impl DataSource {
                 Some(DataSource::NetworkStreaming)
             },
             protocol::DacStatus::SOURCE_ILDA_PLAYBACK_SD => {
-                IldaPlaybackFlags::from_bits(flags)
+                Some(IldaPlaybackFlags::from_bits_truncate(flags))
                     .map(DataSource::IldaPlayback)
             },
             protocol::DacStatus::SOURCE_INTERNAL_ABSTRACT_GENERATOR => {
-                InternalAbstractGeneratorFlags::from_bits(flags)
+                Some(InternalAbstractGeneratorFlags::from_bits_truncate(flags))
                     .map(DataSource::InternalAbstractGenerator)
             },
             _ => None,
@@ -556,8 +546,6 @@ impl Error for ProtocolError {
             ProtocolError::UnknownLightEngineState => "unknown light engine state",
             ProtocolError::UnknownPlaybackState => "unknown playback state",
             ProtocolError::UnknownDataSource => "unknown data source",
-            ProtocolError::UnknownLightEngineFlags => "unknown light engine flags",
-            ProtocolError::UnknownPlaybackFlags => "unknown playback flags",
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where the DAC status constructor would return early with
an error when a hw_version 10 DAC would return non-zeroed values on
un-specified bits.