### PR TITLE
Add timeout support to ether-dream DAC `Stream`. Publish 0.2.5.

### DIFF
--- a/ether-dream/Cargo.toml
+++ b/ether-dream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ether-dream"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A full implementation of the Ether Dream Laster DAC protocol."
 readme = "../README.md"


### PR DESCRIPTION
Adds the following functions:

- `connect_timeout`
- `Stream::set_read_timeout`
- `Stream::set_write_timeout`
- `Stream::set_timeout`

These call into the associated underlying `TcpStream` functions.